### PR TITLE
Add missing numpy import

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Some of the examples use additional libraries. You can install them with:
 pip3 install fonts font-manrope pyyaml adafruit-io numpy
 ```
 
+You may also need to install `libatlas-base-dev`
+
+```
+sudo apt-get install libatlas-base-dev
+```
+
 # Using The Library
 
 Import the `weatherhat` module and create an instance of the `WeatherHAT` class.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Latest/development library from GitHub:
 Some of the examples use additional libraries. You can install them with:
 
 ```bash
-pip3 install fonts font-manrope pyyaml adafruit-io
+pip3 install fonts font-manrope pyyaml adafruit-io numpy
 ```
 
 # Using The Library


### PR DESCRIPTION
Found numpy was a missing required import while setting up my weather station.

You may need to update the website tutorial docs if they are not generated from this.